### PR TITLE
Pressweb and docs

### DIFF
--- a/kubesae/ansible/deploy.py
+++ b/kubesae/ansible/deploy.py
@@ -1,22 +1,34 @@
+import os
+
 import invoke
 
 
 @invoke.task
 def install_requirements(c):
     """Install ansible-galaxy requirements.yml"""
+    req_file = "requirements.yml" if os.path.exists("deploy/requirements.yml") else "requirements.yaml"
     with c.cd("deploy/"):
-        c.run("ansible-galaxy install -f -r requirements.yml -p roles/")
+        c.run(f"ansible-galaxy install -f -r '{req_file}' -p roles/")
 
 
 @invoke.task(pre=[install_requirements], default=True)
 def ansible_deploy(c, env=None, tag=None):
-    """Deploy K8s application."""
+    """
+    Deploy K8s application.
+
+    Config:
+
+        env: Name of environment to deploy to
+        tag: Image tag to deploy (default: same as default tag for build & push)
+
+    """
     if env is None:
         env = c.config.env
     if tag is None:
         tag = c.config.tag
+    playbook = "deploy.yaml" if os.path.exists("deploy/deploy.yaml") else "deploy.yml"
     with c.cd("deploy/"):
-        c.run(f"ansible-playbook deploy.yml -l {env} -e k8s_container_image_tag={tag} -vv")
+        c.run(f"ansible-playbook {playbook} -l {env} -e k8s_container_image_tag={tag} -vv")
 
 
 deploy = invoke.Collection("deploy")

--- a/kubesae/image.py
+++ b/kubesae/image.py
@@ -9,7 +9,10 @@ from colorama import Style
 
 @invoke.task()
 def generate_tag(c):
-    """Generate tag based on local branch & commit hash."""
+    """
+    Generate tag based on local branch & commit hash.
+    Set the config "tag" to the resulting tag.
+    """
     if not hasattr(c.config, "tag"):
         # gather build context
         branch = c.run("git rev-parse --abbrev-ref HEAD", hide="out").stdout.strip()
@@ -21,7 +24,15 @@ def generate_tag(c):
 
 @invoke.task(pre=[generate_tag])
 def build_image(c, tag=None):
-    """Build Docker image using docker-compose."""
+    """
+    Build Docker image using docker-compose.  Tags with <tag> parameter
+    and "latest".
+
+    Config:
+
+        tag: tag to apply. (Will be generated from git branch/commit
+        if not set).
+    """
     if tag is None:
         tag = c.config.tag
     # build app container
@@ -33,7 +44,16 @@ def build_image(c, tag=None):
 
 @invoke.task(pre=[build_image], default=True)
 def push_image(c, tag=None):
-    """Push Docker image to remote repository."""
+    """
+    Push Docker image to remote repository.
+
+    Config:
+
+        repository: where to push. e.g. github.com/pressweb
+
+        tag: tag to push. (Will be generated from git branch/commit
+        if not set).
+    """
     if tag is None:
         tag = c.config.tag
     print(Style.DIM + f"Pushing {tag} to {c.config.repository}")

--- a/kubesae/providers/aws.py
+++ b/kubesae/providers/aws.py
@@ -9,24 +9,39 @@ from colorama import Style
 
 @invoke.task()
 def aws_docker_login(c):
-    """Obtain ECR credentials to use with docker login."""
+    """
+    Obtain ECR credentials to use with docker login.
+
+    Config:
+
+        aws.region: Name of AWS region (default: us-east-1)
+        repository: Name of docker repository, e.g. dockerhub.com/pressweb.
+    """
     registry = c.config.repository.split("/")[0]
+    region = c.config.aws.get("region", "us-east-1")
     print(Style.DIM + f"Performing {registry} registry authentication")
     c.run(
-        f"aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin {registry}"
+        f"aws ecr get-login-password --region {region} | docker login --username AWS --password-stdin {registry}"
     )
 
 
 @invoke.task()
 def configure_eks_kubeconfig(c, cluster=None, region=None):
-    """Obtain EKS access token."""
+    """
+    Obtain EKS access token.
+
+    Config:
+
+        aws.region: Name of AWS region (default: us-east-1)
+        cluster: Name of EKS cluster
+    """
     if not cluster:
         cluster = c.config.cluster
     if not region:
-        region = "us-east-1"
+        region = c.config.aws.get("region", "us-east-1")
     c.run(f"aws eks update-kubeconfig --name {cluster} --region {region}")
 
 
 aws = invoke.Collection("aws")
-aws.add_task(aws_docker_login, "docker_login")
-aws.add_task(configure_eks_kubeconfig, "configure_eks_kubeconfig")
+aws.add_task(aws_docker_login, "docker-login")
+aws.add_task(configure_eks_kubeconfig, "configure-eks-kubeconfig")

--- a/tasks.py
+++ b/tasks.py
@@ -1,6 +1,6 @@
 import invoke
 from colorama import init
-from invocations import *
+from kubesae import image, aws, deploy, pod
 
 
 init(autoreset=True)
@@ -17,4 +17,17 @@ ns.add_collection(aws)
 ns.add_collection(deploy)
 ns.add_collection(pod)
 ns.add_task(staging)
-ns.configure({"run": {"echo": True}})
+
+ns.configure(
+    {
+        "app": "pressweb",
+        "aws": {
+            "region": "us-west-2",
+        },
+        "cluster": "Pressweb-EKS-cluster",
+        "repository": "354308461188.dkr.ecr.us-west-2.amazonaws.com/pressweb",
+        "run": {
+            "echo": True,
+        }
+    }
+)


### PR DESCRIPTION
* Tweak so we can use this for pressweb.
* Flesh out the docs correspondingly.

Trying to handle `.yml` vs. `.yaml` files is done rather awkwardly here. It works, but any way to do this more smoothly would be welcome.