### PR TITLE
Substitutes docker in place of docker-compose for the build

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,7 @@ Image
 build
 ~~~~~
 
-    Builds the docker image using docker-compose.
+    Builds and tags from a Dockerfile.
 
 push
 ~~~~

--- a/invoke.yaml
+++ b/invoke.yaml
@@ -1,0 +1,4 @@
+app: test_app
+repository: TEST_REPO
+run:
+  pty: True

--- a/kubesae/image.py
+++ b/kubesae/image.py
@@ -24,7 +24,7 @@ def generate_tag(c):
 
 @invoke.task(pre=[generate_tag])
 def build_image(c, tag=None, dockerfile=None):
-    """Build Docker image using docker-compose.
+    """Build Docker image using docker build.
 
     Params:
         tag: A user supplied tag for the image

--- a/kubesae/image.py
+++ b/kubesae/image.py
@@ -23,20 +23,22 @@ def generate_tag(c):
 
 
 @invoke.task(pre=[generate_tag])
-def build_image(c, tag=None):
+def build_image(c, tag=None, dockerfile=None):
     """Build Docker image using docker-compose.
 
     Params:
         tag: A user supplied tag for the image
+        dockerfile: A non-standard Dockerfile location and/or name 
     
-    Usage: inv image.build --tag=<TAG>
+    Usage: inv image.build --tag=<TAG> --dockerfile=<PATH_TO_DOCKERFILE>
     """
     if tag is None:
         tag = c.config.tag
-    # build app container
-    c.run("docker-compose build app", echo=True)
+    if dockerfile is None:
+        dockerfile = "Dockerfile"
+    # build app image
     print(Style.DIM + f"Tagging {tag}")
-    c.run(f"docker tag {c.config.app}:latest {c.config.app}:{tag}", echo=True)
+    c.run(f"docker build -t {c.config.app}:latest -t {c.config.app}:{tag} -f {dockerfile} .", echo=True)
     c.config.tag = tag
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -1,6 +1,6 @@
 import invoke
 from colorama import init
-from invocations import *
+from kubesae import *
 
 
 init(autoreset=True)

--- a/test_files/Dockerfile
+++ b/test_files/Dockerfile
@@ -1,0 +1,2 @@
+from busybox:latest AS busybox-test
+CMD ["echo", "Dockerfile"]

--- a/test_files/Dockerfile.test
+++ b/test_files/Dockerfile.test
@@ -1,0 +1,2 @@
+from busybox:latest as busybox-test
+CMD ["echo", "Dockerfile.test"]


### PR DESCRIPTION
Seemed odd to have a `docker-compose build` step then a `docker tag` step, so this changes that.

Also adds a test_files directory with two dummy Dockerfiles for testing purposes.

Modifies the docs.