### PR TITLE
Warn user if working directory is dirty (but don't halt)

### DIFF
--- a/kubesae/image.py
+++ b/kubesae/image.py
@@ -16,6 +16,9 @@ def generate_tag(c):
     Usage: inv image.tag
     """
     if not hasattr(c.config, "tag"):
+        dirty = c.run("git status --short").stdout.strip()
+        if dirty:
+            print(Fore.RED + "The working tree is dirty. Commit or stash your changes if you care about a stable tag name.")
         # gather build context
         branch = c.run("git rev-parse --abbrev-ref HEAD", hide="out").stdout.strip()
         branch = branch.replace("/", "-")  # clean branch name

--- a/kubesae/image.py
+++ b/kubesae/image.py
@@ -16,14 +16,14 @@ def generate_tag(c):
     Usage: inv image.tag
     """
     if not hasattr(c.config, "tag"):
-        dirty = c.run("git status --short").stdout.strip()
-        if dirty:
-            print(Fore.RED + "The working tree is dirty. Commit or stash your changes if you care about a stable tag name.")
         # gather build context
         branch = c.run("git rev-parse --abbrev-ref HEAD", hide="out").stdout.strip()
         branch = branch.replace("/", "-")  # clean branch name
         commit = c.run("git rev-parse --short HEAD", hide="out").stdout.strip()
-        c.config.tag = f"{branch}-{commit}"
+        dirty = c.run("git status --short").stdout.strip()
+        if dirty:
+            dirty = "-dirty"
+        c.config.tag = f"{branch}-{commit}{dirty}"
         print(Style.DIM + f"Set config.tag to {c.config.tag}")
 
 


### PR DESCRIPTION
Closes #7 

This just prints a warning to the console if the tree is dirty.