### PR TITLE
Support Having Docker Env File

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -209,6 +209,23 @@ up
 
     Brings up the deployable image locally in docker-compose for testing
 
+write_docker_env_file
+~~~~~~~~~~~~~~~~~~~~~
+
+    Looks for a config variable named "docker_env_file_template_path", and if such
+    a config variable exists, then it tries to run the commands in the file. The
+    results of the commands are written into a file named ``docker_env_file``. The
+    docker env template file should have 1 variable per line, each set to
+    the command that would get that variable's value.
+    For example::
+     MOST_RECENT_GIT_REVISION=git rev-parse --short HEAD
+     GIT_BRANCH=git rev-parse --abbrev-ref HEAD
+
+    Running ``write_docker_env_file()`` on such a template will create a
+    ``docker_env_file`` that will look like::
+     MOST_RECENT_GIT_REVISION=jksd76hj
+     GIT_BRANCH=my-current-git-branch
+
 Pod
 ---
 
@@ -230,7 +247,7 @@ debian
 fetch_namespace_var
 ~~~~~~~~~~~~~~~~~~~
 
-    Takes a variable name that may be present on a running container. Queries the 
+    Takes a variable name that may be present on a running container. Queries the
     container for the value of that variable and returns it as a Result object.
 
 get_db_dump

--- a/kubesae/image.py
+++ b/kubesae/image.py
@@ -95,6 +95,10 @@ def build_image(c, tag=None, dockerfile=None):
 
     Usage: inv image.build --tag=<TAG> --dockerfile=<PATH_TO_DOCKERFILE>
     """
+    # If docker_env_file_template is set in the config, then run write_docker_env_file().
+    if c.config.get("docker_env_file_template_path"):
+        write_docker_env_file(c)
+
     if tag is None:
         tag = c.config.tag
     if dockerfile is None:

--- a/kubesae/image.py
+++ b/kubesae/image.py
@@ -4,7 +4,63 @@ Provides utilities to build and push Docker images.
 """
 
 import invoke
+import subprocess
 from colorama import Style
+
+
+@invoke.task()
+def write_docker_env_file(c):
+    """
+    Write a docker_env_file, based on the c.docker_env_file_template configuration.
+
+    Usage: inv image.write_docker_env_file
+
+    Config:
+
+        docker_env_file_template_path: Path to the template for the docker_env_file,
+            which should have variable names, and commands to get their values, like:
+            MOST_RECENT_GIT_REVISION=git rev-parse --short HEAD
+            GIT_BRANCH=git rev-parse --abbrev-ref HEAD
+    """
+    # This is the config variable that should define the path to the docker_env_file template.
+    docker_env_file_template_var_name = "docker_env_file_template_path"
+
+    if c.config.get(docker_env_file_template_var_name):
+        # This is the content that will be written to the docker_env_file at the
+        # end of this method.
+        docker_env_file_content = ""
+
+        # Open the template file, and loop through its lines, running the command
+        # for each line.
+        with open(c.config[docker_env_file_template_var_name], "r") as docker_env_file_template:
+            for line in docker_env_file_template.read().split("\n"):
+                # If the line is truthy (not empty), then split it up into the
+                # variable name and the command. Then run the command, and add
+                # its result into the docker_env_file_content.
+                # For example, if the line is DEALER_REVISION=git rev-parse --short HEAD,
+                # then var_name will be DEALER_REVISION, and command will be
+                # "git rev-parse --short HEAD".
+                if line:
+                    # If the line doesn't have an equal sign (for example, a comment),
+                    # then just add the line to the docker_env_file_content.
+                    if line.count("=") == 0:
+                        docker_env_file_content += f"{line}\n"
+                    else:
+                        var_name = line.split("=")[0]
+                        command = line[len(var_name) + 1:]
+                        result = subprocess.run(
+                            command,
+                            capture_output=True,
+                            shell=True
+                        ).stdout.decode('utf-8').rstrip()
+                        docker_env_file_content += f"{var_name}={result}\n"
+
+        # Write the docker_env_file_content into the docker_env_file.
+        with open("docker_env_file", "w") as docker_env_file:
+            docker_env_file.write(docker_env_file_content)
+        print("docker_env_file written")
+    else:
+        raise KeyError(f"Please set '{docker_env_file_template_var_name}' in config file")
 
 
 @invoke.task()
@@ -91,6 +147,7 @@ def stop(c):
 
 
 image = invoke.Collection("image")
+image.add_task(write_docker_env_file, "write-docker-env-file")
 image.add_task(generate_tag, "tag")
 image.add_task(build_image, "build")
 image.add_task(push_image, "push")


### PR DESCRIPTION
**Update:**
This original reason for this pull request was the `dealer` library in a Docker image needing to know a git commit hash. However, it seems it may be easier to use Django's [`ManifestFilesMixin`](https://docs.djangoproject.com/en/3.0/ref/contrib/staticfiles/#manifestfilesmixin) instead of `dealer`. I'm going to keep this pull request here for now, in case it's useful to others, or someone else wants to comment on it. If it's not needed, we can also just close it.

**Original Description:**
The problem:
Projects that use the `dealer` library expect that each deploy that has new commits will force the servers to serve bundles (`bundle.js`, `bundle.css` etc.) with unique names (`dealer` allows projects to add the shortened `git` commit hash to the end of the bundle name, like `bundle.js?rev=86c6d480`), so that browsers get a new version of the bundle each time the commit hash changes. However, our Dockerfiles do not include the `.git` directory, so `dealer` can't add anything meaningful to the bundle name (so the JavaScript bundle looks like `bundle.js?rev=`).

Solution:
An invoke command (`write_docker_env_file()`) looks for a `"docker_env_file_template"` key name in the `invoke-kubesae` configuration. If it is set, then `write_docker_env_file()` reads that file, and runs the command on each line of that file. The template file should have variables, and the command to get each variable’s name. It should look something like: 
```
DEALER_REVISION=git rev-parse --short HEAD
DEALER_TAG=git describe --always --tags 
```

The result of the command from each line is then written for the appropriate	 variable into a `docker_env_file`, which looks something like:
```
DEALER_REVISION=53d052dd
DEALER_TAG=2020-06-12-224-g53d052dd
```

The already existing `build_image()` command now also runs `write_docker_env_file()` prior building the Docker image.
It will be the responsibility of the Dockerfile to have something like `COPY docker_env_file /code/.env`, so that the `docker_env_file` ends up in the Docker container. Then, `dealer` can use the environment variables defined to determine the git commit hash.