### PR TITLE
Update Shell Command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -230,7 +230,7 @@ debian
 fetch_namespace_var
 ~~~~~~~~~~~~~~~~~~~
 
-    Takes a variable name that may be present on a running container. Queries the 
+    Takes a variable name that may be present on a running container. Queries the
     container for the value of that variable and returns it as a Result object.
 
 get_db_dump
@@ -247,3 +247,7 @@ shell
 ~~~~~
 
     Gives you a shell on the application pod. (Default)
+
+    Config:
+
+        container_name: Name of the Docker container.

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1,6 +1,10 @@
 Releases
 ========
 
+vNext
+-----
+* shell command uses (and requires) container_name config variable
+
 v0.0.6, 2020-07-13
 ~~~~~~~~~~~~~~~~~~
 

--- a/kubesae/pod.py
+++ b/kubesae/pod.py
@@ -5,9 +5,9 @@ import invoke
 def shell(c):
     """Gives you a shell on the application pod.
 
-    Usage: inv <ENVIRONMENT> pod
+    Usage: inv <ENVIRONMENT> pod.shell
     """
-    c.run(f"kubectl exec -it deploy/app -n {c.config.namespace} bash")
+    c.run(f"kubectl exec -it deploy/{c.config.container_name} -n {c.config.namespace} bash")
 
 
 @invoke.task()
@@ -50,7 +50,7 @@ def clean_migrations(c):
 
 @invoke.task
 def fetch_namespace_var(c, fetch_var, hide=False):
-    """Takes a variable name that may be present on a running container. Queries the 
+    """Takes a variable name that may be present on a running container. Queries the
     container for the value of that variable and returns it as a Result object.
 
     Args:


### PR DESCRIPTION
This pull request updates the `shell` command to use the configuration's `container_name`, rather than assuming that the container is named "app".