### PR TITLE
Add command to run alternate playbook

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -166,6 +166,12 @@ install
 
     Install ansible-galaxy requirements.yml.
 
+playbook
+~~~~~~~~
+
+    Run a specified Ansible playbook, located in the ``deploy/`` directory.
+
+
 GCP
 ---
 

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1,22 +1,24 @@
 Releases
 ========
 
-vNext, 2020-MM-DD
-~~~~~~~~~~~~~~~~~
-* Add command to run an alternate playbook
+v0.0.9, 2020-10-29
+~~~~~~~~~~~~~~~~~~
+* Add command to run an alternate playbook (#21)
+
 
 v0.0.8, 2020-09-15
 ~~~~~~~~~~~~~~~~~~
 * Update shell command to use `container_name` (rather than "app")
+
 
 v0.0.7, 2020-07-20
 ~~~~~~~~~~~~~~~~~~
 * Add support for Google Cloud Platform
 * Shell command uses (and requires) container_name config variable
 
+
 v0.0.6, 2020-07-13
 ~~~~~~~~~~~~~~~~~~
-
 * Delete old migrations pods with single command
 * Add command to delete collectstatic pods
 * Add command to fetch an environment variable from container
@@ -24,29 +26,29 @@ v0.0.6, 2020-07-13
 * Add command to restore a database dump
 * Updates docstrings
 
+
 v0.0.5, 2020-06-22
 ~~~~~~~~~~~~~~~~~~
-
 * Build images with docker, rather than docker-compose
+
 
 v0.0.4, 2020-06-22
 ~~~~~~~~~~~~~~~~~~
-
 * Add and improve docstrings
 * Package all the packages, including sub-packages
 * Support either .yaml or .yml extension
 
+
 v0.0.3, 2020-04-28
 ~~~~~~~~~~~~~~~~~~
-
 * Bump in release version
+
 
 v0.0.2, 2020-04-28
 ~~~~~~~~~~~~~~~~~~
-
 * Fix package name
+
 
 v0.0.1, 2020-04-27
 ~~~~~~~~~~~~~~~~~~
-
 * Initial release

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1,6 +1,10 @@
 Releases
 ========
 
+vNext, 2020-MM-DD
+~~~~~~~~~~~~~~~~~
+* Add command to run an alternate playbook
+
 v0.0.8, 2020-09-15
 ~~~~~~~~~~~~~~~~~~
 * Update shell command to use `container_name` (rather than "app")

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='invoke-kubesae',
-    version='0.0.8',
+    version='0.0.9',
     packages=find_packages(),
     url='https://github.com/caktus/invoke-kubesae',
     author='Caktus Group',


### PR DESCRIPTION
I stole this from @copelco's backup role when I was setting up PW backups, but figure it would be good to have in kubesae.

This allows you to run an ad-hoc playbook rather than the default `deploy.yaml` (Useful for setting up the cluster, modifying the cluster, or setting up hosting services tasks)