### PR TITLE
Adds an info collection

### DIFF
--- a/kubesae/__init__.py
+++ b/kubesae/__init__.py
@@ -1,5 +1,6 @@
 from .image import *
 from .pod import *
+from .info import *
 from .ansible.deploy import *
 from .ansible.vars import *
 from .providers.aws import *

--- a/kubesae/info.py
+++ b/kubesae/info.py
@@ -1,0 +1,39 @@
+import invoke
+import yaml
+
+@invoke.task(default=True)
+def get_ansible_vars(c, var=None):
+    """A command to inspect any ansible varible by environment. If no variable is specified then it will
+    print out the current k8s environment variables.
+
+    Params:
+        var: A variable available to a host when called.
+
+    Usage: inv <ENVIRONMENT> info
+           inv <ENVIRONEMNT> info --var=<ANSIBLE_VAR>
+    """
+    if not var:
+        var = "k8s_environment_variables"
+    with c.cd("deploy/"):
+        c.run(f"ansible {c.config.env} -m debug -a var='{var}' -e '@host_vars/{c.config.env}.yml'")
+
+@invoke.task
+def pod_stats(c):
+    """Report total pods vs pod capacity in a cluster.
+    
+    Params: None
+
+    Usage: inv info.pod-stats
+    """
+    nodes = yaml.safe_load(c.run("kubectl get nodes -o yaml", hide="out").stdout)
+    pod_capacity = sum([int(item["status"]["capacity"]["pods"]) for item in nodes["items"]])
+    pod_total = c.run(
+        "kubectl get pods --all-namespaces | grep Running | wc -l", hide="out"
+    ).stdout.strip()
+    print(f"Running pods: {pod_total}")
+    print(f"Maximum pods: {pod_capacity}")
+    print(f"Total nodes: {len(nodes['items'])}")
+
+info = invoke.Collection("info")
+info.add_task(get_ansible_vars)
+info.add_task(pod_stats)

--- a/kubesae/info.py
+++ b/kubesae/info.py
@@ -10,7 +10,7 @@ def get_ansible_vars(c, var=None):
         var: A variable available to a host when called.
 
     Usage: inv <ENVIRONMENT> info
-           inv <ENVIRONEMNT> info --var=<ANSIBLE_VAR>
+           inv <ENVIRONMENT> info --var=<ANSIBLE_VAR>
     """
     if not var:
         var = "k8s_environment_variables"

--- a/tasks.py
+++ b/tasks.py
@@ -1,6 +1,6 @@
 import invoke
 from colorama import init
-from kubesae import image, aws, deploy, pod
+from kubesae import image, aws, deploy, pod, info
 
 
 init(autoreset=True)
@@ -18,6 +18,7 @@ ns.add_collection(image)
 ns.add_collection(aws)
 ns.add_collection(deploy)
 ns.add_collection(pod)
+ns.add_collection(info)
 ns.add_task(staging)
 
 ns.configure(


### PR DESCRIPTION
PR adds a couple of commands that I find useful.

If we think these are appropriate to add, I've located them in an **info** package, but there is a good argument that they are namespaced enough that they could be in other existing packages.  The main thought for putting them here is that they are primarily meant to support maintenance and other tasks that might not require **doing** anything to a cluster just getting information about it.

