### PR TITLE
Sync media tree task

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -289,4 +289,4 @@ shell
 
 sync-media
 ~~~~~~~~~~
-    Syncs the S3 media buckets between two namespaces (e.g. production to staging)
+    Syncs a media bucket between two namespaces (e.g. `production` to `staging`, or `staging` to `local`).

--- a/README.rst
+++ b/README.rst
@@ -286,3 +286,7 @@ shell
     Config:
 
         container_name: Name of the Docker container.
+
+sync-media
+~~~~~~~~~~
+    Syncs the S3 media buckets between two namespaces (e.g. production to staging)

--- a/kubesae/pod.py
+++ b/kubesae/pod.py
@@ -117,8 +117,8 @@ def sync_media_tree(
     """Sync an S3 media tree for a given environment to another. 
 
     Args:
-        target_env   (string, required): A deployment host defined in ansible host_vars (e.g. "production", "staging", "dev").
-        media_bucket (string, required): The variable name for media defined in settings and host_vars.
+        target_env   (string, required): A deployment host defined in ansible host_vars (e.g. "production", "staging", "dev"). DEFAULT: staging
+        media_bucket (string, required): The variable name for media defined in settings and host_vars. DEFAULT: MEDIA_STORAGE_BUCKET_NAME
         acl          (string, required): Sets the access policy on each object. DEFAULT: public-read
                                          Possible values: [
                                             private, public-read, public-read-write, authenticated-read, 

--- a/kubesae/pod.py
+++ b/kubesae/pod.py
@@ -105,61 +105,6 @@ def restore_db_from_dump(c, db_var, filename):
     )
     c.run(command)
 
-@invoke.task
-def sync_media_tree(
-    c,
-    target_env="staging",
-    media_bucket="MEDIA_STORAGE_BUCKET_NAME",
-    acl="public-read",
-    dry_run=False,
-    delete=False,
-):
-    """Sync an S3 media tree for a given environment to another. 
-
-    Args:
-        target_env   (string, required): A deployment host defined in ansible host_vars (e.g. "production", "staging", "dev"). DEFAULT: staging
-        media_bucket (string, required): The variable name for media defined in settings and host_vars. DEFAULT: MEDIA_STORAGE_BUCKET_NAME
-        acl          (string, required): Sets the access policy on each object. DEFAULT: public-read
-                                         Possible values: [
-                                            private, public-read, public-read-write, authenticated-read, 
-                                            aws-exec-read, bucket-owner-read,bucket-owner-full-control,
-                                            log-delivery-write
-                                        ]
-        dry_run      (boolean, optional): Outputs the result to stdout without applying the action
-        delete       (boolean, optional): If set, deletes files on the target that do not exist on the source.
-
-    Usage:
-        inv production sync-media --dry-run: 
-            Will simulate a sync from production to staging using the s3 bucket defined in MEDIA_STORAGE_BUCKET with no acl applied.
-        
-        inv production sync-media --dry-run --delete
-            Will display the files that will be deleted from the staging s3 bucket defined in MEDIA_STORAGE_BUCKET.
-        
-        inv production sync-media --media-bucket="MEDIA" --acl public-read --delete
-            Will sync files from the s3 bucket defined in the environment variable "MEDIA" to a staging bucket with the acl of each object set to 'public-read', and
-            will delete objects on the staging bucket that do not exist on the production bucket.
-    """
-
-    cc = invoke.context.Context()
-    cc.config.env = target_env
-    cc.config.namespace = f"{c.config.app}-{target_env}"
-    cc.config.container_name = c.config.container_name
-
-    source_media_name = fetch_namespace_var(
-        c, fetch_var=f"{media_bucket}"
-    ).stdout.strip()
-    target_media_name = fetch_namespace_var(
-        cc, fetch_var=f"{media_bucket}"
-    ).stdout.strip()
-
-    dr = ""
-    dl = ""
-    if dry_run:
-        dr = "--dryrun"
-    if delete:
-        dl = "--delete"
-    c.run(f"aws s3 sync --acl {acl} s3://{source_media_name} s3://{target_media_name} {dr} {dl}")
-
 
 pod = invoke.Collection("pod")
 pod.add_task(shell, "shell")
@@ -170,4 +115,3 @@ pod.add_task(clean_migrations, "clean_migrations")
 pod.add_task(get_db_dump, "get_db_dump")
 pod.add_task(restore_db_from_dump, "restore_db_from_dump")
 pod.add_task(fetch_namespace_var, "fetch_namespace_var")
-pod.add_task(sync_media_tree, "sync_media")

--- a/kubesae/providers/aws.py
+++ b/kubesae/providers/aws.py
@@ -5,6 +5,7 @@ Provides helpful EKS and ECR utilities.
 
 import invoke
 from colorama import Style
+from kubesae.pod import fetch_namespace_var
 
 
 @invoke.task()
@@ -45,7 +46,72 @@ def configure_eks_kubeconfig(c, cluster=None, region=None):
         region = c.config.aws.get("region", "us-east-1")
     c.run(f"aws eks update-kubeconfig --name {cluster} --region {region}")
 
+@invoke.task(name="sync_media")
+def sync_media_tree(
+    c,
+    target_env="staging",
+    media_bucket="MEDIA_STORAGE_BUCKET_NAME",
+    acl="public-read",
+    local_target="./media",
+    dry_run=False,
+    delete=False,
+    local=False,
+):
+    """Sync an S3 media tree for a given environment/namespace to another. 
+
+    Args:
+        target_env   (string, required): A deployment host defined in ansible host_vars (e.g. "production", "staging", "dev"). DEFAULT: staging
+        media_bucket (string, required): The variable name for media defined in settings and host_vars. DEFAULT: MEDIA_STORAGE_BUCKET_NAME
+        acl          (string, required): Sets the access policy on each object. DEFAULT: public-read
+                                         Possible values: [
+                                            private, public-read, public-read-write, authenticated-read, 
+                                            aws-exec-read, bucket-owner-read,bucket-owner-full-control,
+                                            log-delivery-write
+                                        ]
+        local_target (string, optional): Sets a default target for local syncs
+        dry_run      (boolean, optional): Outputs the result to stdout without applying the action
+        delete       (boolean, optional): If set, deletes files on the target that do not exist on the source.
+        local        (boolean, optional): If set, syncs media files to the location defined by the "local_target" parameter.
+
+    Usage:
+        inv production aws.sync-media --dry-run: 
+            Will simulate a sync from production to staging using the s3 bucket defined in MEDIA_STORAGE_BUCKET with no acl applied.
+        
+        inv production aws.sync-media --dry-run --delete
+            Will display the files that will be deleted from the staging s3 bucket defined in MEDIA_STORAGE_BUCKET.
+        
+        inv production aws.sync-media --media-bucket="MEDIA" --acl public-read --delete
+            Will sync files from the s3 bucket defined in the environment variable "MEDIA" to a staging bucket with the acl of each object set to 'public-read', and
+            will delete objects on the staging bucket that do not exist on the production bucket.
+        
+        inv production aws.sync-media --local --delete
+            Will sync files from the production s3 bucket to "<PROJECT_ROOT>/media"
+    """
+
+    cc = invoke.context.Context()
+    cc.config.env = target_env
+    cc.config.namespace = f"{c.config.app}-{target_env}"
+    cc.config.container_name = c.config.container_name
+
+    source_media_name = fetch_namespace_var(
+        c, fetch_var=f"{media_bucket}"
+    ).stdout.strip()
+    target_media_name = fetch_namespace_var(
+        cc, fetch_var=f"{media_bucket}"
+    ).stdout.strip()
+
+    dr = ""
+    dl = ""
+    if dry_run:
+        dr = "--dryrun"
+    if delete:
+        dl = "--delete"
+    if local:
+        c.run(f"aws s3 sync --acl {acl} s3://{source_media_name} {local_target} {dr} {dl}")
+    c.run(f"aws s3 sync --acl {acl} s3://{source_media_name} s3://{target_media_name} {dr} {dl}")
+
 
 aws = invoke.Collection("aws")
 aws.add_task(aws_docker_login, "docker-login")
 aws.add_task(configure_eks_kubeconfig, "configure-eks-kubeconfig")
+aws.add_task(sync_media_tree, "sync_media")

--- a/kubesae/providers/aws.py
+++ b/kubesae/providers/aws.py
@@ -52,10 +52,9 @@ def sync_media_tree(
     target_env="staging",
     media_bucket="MEDIA_STORAGE_BUCKET_NAME",
     acl="public-read",
-    local_target="./media",
+    local_target=None,
     dry_run=False,
     delete=False,
-    local=False,
 ):
     """Sync an S3 media tree for a given environment/namespace to another. 
 
@@ -68,7 +67,7 @@ def sync_media_tree(
                                             aws-exec-read, bucket-owner-read,bucket-owner-full-control,
                                             log-delivery-write
                                         ]
-        local_target (string, optional): Sets a default target for local syncs
+        local_target (string, optional): Sets a target directory for local syncs
         dry_run      (boolean, optional): Outputs the result to stdout without applying the action
         delete       (boolean, optional): If set, deletes files on the target that do not exist on the source.
         local        (boolean, optional): If set, syncs media files to the location defined by the "local_target" parameter.
@@ -106,9 +105,11 @@ def sync_media_tree(
         dr = "--dryrun"
     if delete:
         dl = "--delete"
-    if local:
-        c.run(f"aws s3 sync --acl {acl} s3://{source_media_name} {local_target} {dr} {dl}")
-    c.run(f"aws s3 sync --acl {acl} s3://{source_media_name} s3://{target_media_name} {dr} {dl}")
+
+    target_media_name = f"s3://{target_media_name}"
+    if local_target:
+        target_media_name = local_target
+    c.run(f"aws s3 sync --acl {acl} s3://{source_media_name} {target_media_name} {dr} {dl}")
 
 
 aws = invoke.Collection("aws")

--- a/kubesae/providers/gcp.py
+++ b/kubesae/providers/gcp.py
@@ -66,6 +66,18 @@ def sync_media_tree(
         delete       (boolean, optional): If set, deletes files on the target that do not exist on the source.
 
     Usage:
+        inv production gcp.sync-media --dry-run: 
+            Will simulate a sync from production to staging using the bucket defined in MEDIA_STORAGE_BUCKET.
+        
+        inv production gcp.sync-media --dry-run --delete
+            Will display the files that will be deleted from the staging bucket defined in MEDIA_STORAGE_BUCKET.
+        
+        inv production gcp.sync-media --media-bucket="MEDIA" --delete
+            Will sync files from the bucket defined in the environment variable "MEDIA" to a staging bucket and
+            will delete objects on the staging bucket that do not exist on the production bucket.
+        
+        inv production gcp.sync-media --local-target="./media"
+            Will sync files from the production s3 bucket to "<PROJECT_ROOT>/media"
 
     """
 

--- a/kubesae/providers/gcp.py
+++ b/kubesae/providers/gcp.py
@@ -50,18 +50,19 @@ def configure_gcp_kubeconfig(c, cluster=None, region=None):
 @invoke.task(name="sync_media")
 def sync_media_tree(
     c,
-    target_env="staging",
+    sync_to="staging",
     media_bucket="MEDIA_STORAGE_BUCKET_NAME",
-    local_target=None,
+    local_target="./media",
     dry_run=False,
     delete=False,
 ):
     """Sync a gcloud media tree for a given environment/namespace to another. 
 
     Args:
-        target_env   (string, required): A deployment host defined in ansible host_vars (e.g. "production", "staging", "dev"). DEFAULT: staging
+        sync_to      (string, required): A deployment host defined in ansible host_vars (e.g. "production", "staging", "dev"), or "local". 
+            If set to "local" will sync the tree to a local folder. DEFAULT: staging.
         media_bucket (string, required): The variable name for media defined in settings and host_vars. DEFAULT: MEDIA_STORAGE_BUCKET_NAME
-        local_target (string, optional): Sets a target directory for local syncs
+        local_target (string, optional): Sets a target directory for local syncs. Defaults to "./media"
         dry_run      (boolean, optional): Outputs the result to stdout without applying the action
         delete       (boolean, optional): If set, deletes files on the target that do not exist on the source.
 
@@ -76,33 +77,41 @@ def sync_media_tree(
             Will sync files from the bucket defined in the environment variable "MEDIA" to a staging bucket and
             will delete objects on the staging bucket that do not exist on the production bucket.
         
-        inv production gcp.sync-media --local-target="./media"
-            Will sync files from the production bucket to "<PROJECT_ROOT>/media"
+        inv production gcp.sync-media --sync-to="local" --local-target="./public/media"
+            Will sync files from the production bucket to "<PROJECT_ROOT>/public/media"
 
     """
-
-    cc = invoke.context.Context()
-    cc.config.env = target_env
-    cc.config.namespace = f"{c.config.app}-{target_env}"
-    cc.config.container_name = c.config.container_name
-
+    sync_from = c.config.env
+    target_media_name = ""
+    dr = ""
+    dl = ""
+    
     source_media_name = fetch_namespace_var(
         c, fetch_var=f"{media_bucket}"
     ).stdout.strip()
-    target_media_name = fetch_namespace_var(
-        cc, fetch_var=f"{media_bucket}"
-    ).stdout.strip()
 
-    dr = ""
-    dl = ""
+    if sync_from == sync_to:
+        print("Source and Target environments are the same. Nothing to be done.")
+        return
+
+    if sync_to == "local":
+        target_media_name = local_target
+    else:
+        cc = invoke.context.Context()
+        cc.config.env = sync_to
+        cc.config.namespace = f"{c.config.app}-{sync_to}"
+        cc.config.container_name = c.config.container_name
+
+        target_media_name = fetch_namespace_var(
+            cc, fetch_var=f"{media_bucket}"
+        ).stdout.strip()
+        target_media_name = f"gs://{target_media_name}"
+
     if dry_run:
         dr = "-n"
     if delete:
         dl = "-d"
 
-    target_media_name = f"gs://{target_media_name}"
-    if local_target:
-        target_media_name = local_target
     c.run(f"gsutil rsync -r {dr} {dl} gs://{source_media_name} {target_media_name}")
 
 

--- a/kubesae/providers/gcp.py
+++ b/kubesae/providers/gcp.py
@@ -77,7 +77,7 @@ def sync_media_tree(
             will delete objects on the staging bucket that do not exist on the production bucket.
         
         inv production gcp.sync-media --local-target="./media"
-            Will sync files from the production s3 bucket to "<PROJECT_ROOT>/media"
+            Will sync files from the production bucket to "<PROJECT_ROOT>/media"
 
     """
 

--- a/kubesae/providers/gcp.py
+++ b/kubesae/providers/gcp.py
@@ -5,6 +5,7 @@ Provides helpful utilities for working with kubernetes and the Google Container 
 
 import invoke
 from colorama import Style
+from kubesae.pod import fetch_namespace_var
 
 
 @invoke.task()
@@ -46,7 +47,54 @@ def configure_gcp_kubeconfig(c, cluster=None, region=None):
     c.run(f"gcloud config set project {c.config.app}")
     c.run(f"gcloud container clusters get-credentials --region={region} {cluster}")
 
+@invoke.task(name="sync_media")
+def sync_media_tree(
+    c,
+    target_env="staging",
+    media_bucket="MEDIA_STORAGE_BUCKET_NAME",
+    local_target=None,
+    dry_run=False,
+    delete=False,
+):
+    """Sync a gcloud media tree for a given environment/namespace to another. 
+
+    Args:
+        target_env   (string, required): A deployment host defined in ansible host_vars (e.g. "production", "staging", "dev"). DEFAULT: staging
+        media_bucket (string, required): The variable name for media defined in settings and host_vars. DEFAULT: MEDIA_STORAGE_BUCKET_NAME
+        local_target (string, optional): Sets a target directory for local syncs
+        dry_run      (boolean, optional): Outputs the result to stdout without applying the action
+        delete       (boolean, optional): If set, deletes files on the target that do not exist on the source.
+
+    Usage:
+
+    """
+
+    cc = invoke.context.Context()
+    cc.config.env = target_env
+    cc.config.namespace = f"{c.config.app}-{target_env}"
+    cc.config.container_name = c.config.container_name
+
+    source_media_name = fetch_namespace_var(
+        c, fetch_var=f"{media_bucket}"
+    ).stdout.strip()
+    target_media_name = fetch_namespace_var(
+        cc, fetch_var=f"{media_bucket}"
+    ).stdout.strip()
+
+    dr = ""
+    dl = ""
+    if dry_run:
+        dr = "-n"
+    if delete:
+        dl = "-d"
+
+    target_media_name = f"gs://{target_media_name}"
+    if local_target:
+        target_media_name = local_target
+    c.run(f"gsutil rsync -r {dr} {dl} gs://{source_media_name} {target_media_name}")
+
 
 gcp = invoke.Collection("gcp")
 gcp.add_task(gcp_docker_login, "docker-login")
 gcp.add_task(configure_gcp_kubeconfig, "configure-gcp-kubeconfig")
+gcp.add_task(sync_media_tree)


### PR DESCRIPTION
Adds a task to sync media buckets.

This is primarily meant to support backup verification process, periodic staging refreshes from production and local dev setup.

The only icky bit is the duplication of code between providers, but we are already doing that so :shrug: but future work would be nice to make that more abstracted like `inv staging provider.sync-media` with the provider type in global context, and then get a factory from that to do the work.