### PR TITLE
[IK-20] Adds a database backup get task.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .vscode
+.idea
 __pycache__/
 *.pyc
+*.egg-info/

--- a/README.rst
+++ b/README.rst
@@ -286,20 +286,23 @@ up
 Info
 ----
 
-get-ansible-vars
+print-ansible-vars
 ~~~~~~~~~~~~~~~~
 
-    Inspect ansible variables
+    A command to inspect any ansible variable by environment. If no variable is specified then it will
+    print out the current k8s environment variables.
 
     Params:
-
-        var: A variable available to a host when called.
+        c (invoke.Context): The current invoke context.
+        var (string, optional): The ansible variable you want to expose. Defaults to None.
+        yaml (string, optional): An ansible path. Defaults to None.
+        pty (bool, optional): If piping the output to another command you might need this to be False. Defaults to True.
+        hide (bool, optional): If you don't want the results to print to the console set to "out". Defaults to False.
 
 pod-stats
 ~~~~~~~~~
 
     Report total pods vs pod capacity in a cluster.
-
 
 Pod
 ---
@@ -393,3 +396,29 @@ shell
     Config:
 
         container_name: Name of the Docker container.
+
+Utils
+-----
+
+get_backup_from_hosting
+~~~~~~~~~~~~~~~~~~~~~~~
+
+    Downloads a backup from the caktus hosting services bucket
+
+    Params:
+
+        c (invoke.Context): the running context
+        latest (str, optional): Gets the latest backup from the specified temporal period. Defaults to "daily". Options are "daily", "weekly", "monthly", "yearly"
+        profile (str, optional): The AWS profile to allow access to the s3 bucket. DEFAULT: "caktus"
+        backup_name(str, optional): A specific backup filename.
+        list(bool, optional): If set, will list the contents of the bucket for the projects folder and exit.
+
+    The use of this task requires the addition of `hosting_services_backup_folder` to your `tasks.py`
+    configuration:
+
+        ns.configure(
+        {
+            ...
+            "hosting_services_backup_folder": "<PROJECT_FOLDER>",
+            ...
+        }

--- a/kubesae/__init__.py
+++ b/kubesae/__init__.py
@@ -1,6 +1,7 @@
 from .image import *
 from .pod import *
 from .info import *
+from .utils import *
 from .ansible.deploy import *
 from .ansible.vars import *
 from .providers.aws import *

--- a/kubesae/info.py
+++ b/kubesae/info.py
@@ -1,41 +1,41 @@
+import os
 import invoke
 import yaml
 
-@invoke.task("print_ansible_vars")
+
+@invoke.task
 def print_ansible_vars(c, var=None, yaml=None, pty=True, hide=False):
-    """A command to inspect any ansible varible by environment. If no variable is specified then it will
+    """A command to inspect any ansible variable by environment. If no variable is specified then it will
     print out the current k8s environment variables.
 
-    Args:
-        c (invoke.Context): [description]
+    Params:
+        c (invoke.Context): The current invoke context
         var (string, optional): The ansible variable you want to expose. Defaults to None.
         yaml (string, optional): An ansible path. Defaults to None.
-        pty (bool, optional): [description]. Defaults to True.
-        hide (bool, optional): [description]. Defaults to False.
+        pty (bool, optional): If piping the output to another command you might need this to be False. Defaults to True.
+        hide (bool, optional): If you don't want the results to print to the console set to "out". Defaults to False.
 
     Returns:
         invoke.Result
     
     Usage:
-        $ inv staging info.print_ansible_vars
+        $ inv staging info.print-ansible-vars
             Prints all of the environment variables values defined in the 
             "k8s_environment_variables" dictionary located at 
             <PROJECT_ROOT>/deploy/host_vars/staging.yml.
 
-        $ inv staging info.print_ansible_vars --var=foo_bar_baz
+        $ inv staging info.print-ansible-vars --var=foo_bar_baz
             Prints the "foo_bar_baz" value defined in the "foo_bar_baz"
             variable located at <PROJECT_ROOT>/deploy/host_vars/staging.yml
         
-        $ inv staging info.print_ansible_vars --var=foo_bar_baz --yaml="@group_vars/all.yaml"
+        $ inv staging info.print-ansible-vars --var=foo_bar_baz --yaml="@group_vars/all.yaml"
             Prints the "foo_bar_baz" value defined in the "foo_bar_baz"
             variable located at <PROJECT_ROOT>/deploy/group_vars/all.yml
     """
-    yaml_file = f"@host_vars/{c.config.env}.yml"
     expose_var = "k8s_environment_variables"
     if var:
         expose_var = var
-    if yaml:
-        yaml_file = yaml
+    yaml_file = f"@host_vars/{c.config.env}.yml" if os.path.exists(f"deploy/host_vars/{c.config.env}.yml") else f"@host_vars/{c.config.env}.yaml"
 
     cmd = f"ansible {c.config.env} -m debug -a var='{expose_var}' -e '{yaml_file}'"
     with c.cd("deploy/"):
@@ -58,6 +58,7 @@ def pod_stats(c):
     print(f"Running pods: {pod_total}")
     print(f"Maximum pods: {pod_capacity}")
     print(f"Total nodes: {len(nodes['items'])}")
+
 
 info = invoke.Collection("info")
 info.add_task(print_ansible_vars)

--- a/kubesae/info.py
+++ b/kubesae/info.py
@@ -1,21 +1,45 @@
 import invoke
 import yaml
 
-@invoke.task(default=True)
-def get_ansible_vars(c, var=None):
+@invoke.task("print_ansible_vars")
+def print_ansible_vars(c, var=None, yaml=None, pty=True, hide=False):
     """A command to inspect any ansible varible by environment. If no variable is specified then it will
     print out the current k8s environment variables.
 
-    Params:
-        var: A variable available to a host when called.
+    Args:
+        c (invoke.Context): [description]
+        var (string, optional): The ansible variable you want to expose. Defaults to None.
+        yaml (string, optional): An ansible path. Defaults to None.
+        pty (bool, optional): [description]. Defaults to True.
+        hide (bool, optional): [description]. Defaults to False.
 
-    Usage: inv <ENVIRONMENT> info
-           inv <ENVIRONMENT> info --var=<ANSIBLE_VAR>
+    Returns:
+        invoke.Result
+    
+    Usage:
+        $ inv staging info.print_ansible_vars
+            Prints all of the environment variables values defined in the 
+            "k8s_environment_variables" dictionary located at 
+            <PROJECT_ROOT>/deploy/host_vars/staging.yml.
+
+        $ inv staging info.print_ansible_vars --var=foo_bar_baz
+            Prints the "foo_bar_baz" value defined in the "foo_bar_baz"
+            variable located at <PROJECT_ROOT>/deploy/host_vars/staging.yml
+        
+        $ inv staging info.print_ansible_vars --var=foo_bar_baz --yaml="@group_vars/all.yaml"
+            Prints the "foo_bar_baz" value defined in the "foo_bar_baz"
+            variable located at <PROJECT_ROOT>/deploy/group_vars/all.yml
     """
-    if not var:
-        var = "k8s_environment_variables"
+    yaml_file = f"@host_vars/{c.config.env}.yml"
+    expose_var = "k8s_environment_variables"
+    if var:
+        expose_var = var
+    if yaml:
+        yaml_file = yaml
+
+    cmd = f"ansible {c.config.env} -m debug -a var='{expose_var}' -e '{yaml_file}'"
     with c.cd("deploy/"):
-        c.run(f"ansible {c.config.env} -m debug -a var='{var}' -e '@host_vars/{c.config.env}.yml'")
+        return c.run(cmd, pty=pty, hide=hide)
 
 @invoke.task
 def pod_stats(c):
@@ -35,5 +59,5 @@ def pod_stats(c):
     print(f"Total nodes: {len(nodes['items'])}")
 
 info = invoke.Collection("info")
-info.add_task(get_ansible_vars)
+info.add_task(print_ansible_vars)
 info.add_task(pod_stats)

--- a/kubesae/utils.py
+++ b/kubesae/utils.py
@@ -61,7 +61,7 @@ def get_backup_from_hosting(c, latest="daily", backup_name=None, list=False):
         listing = c.run(
             f"aws s3 ls s3://{BASE_BACKUP_BUCKET}/{project_backup_folder}/ --profile caktus",
             pty=False,
-            hide=True,
+            hide="out",
         ).stdout.strip()
 
         dates = [

--- a/kubesae/utils.py
+++ b/kubesae/utils.py
@@ -43,7 +43,6 @@ def get_backup_from_hosting(c, latest="daily", profile="caktus", backup_name=Non
         $ inv utils.get-db-backup --list --profile="client-aws"
             Will list all of the backup files using the a locally configured AWS_PROFILE named "client-aws"
     """
-    c.config.env = "production"
     valid_periods = ['daily', 'weekly', 'monthly', 'yearly']
 
     if "hosting_services_backup_folder" not in c.config.keys():
@@ -66,19 +65,19 @@ def get_backup_from_hosting(c, latest="daily", profile="caktus", backup_name=Non
         print(f"{latest} is not a valid backup interval. Valid intervals are {', '.join(valid_periods)}")
         exit(1)
 
-    listing = c.run(
-        f"aws s3 ls s3://{BASE_BACKUP_BUCKET}/{c.config.hosting_services_backup_folder}/ --profile {profile}",
-        pty=False,
-        hide="out",
-    ).stdout.strip()
-
-    dates = [
-        re.search(r"\d{12}", x).group(0)
-        for x in listing.split("\n")
-        if re.search(f"^.*{latest}-.*", x)
-    ]
-
     if not backup_name:
+        listing = c.run(
+            f"aws s3 ls s3://{BASE_BACKUP_BUCKET}/{c.config.hosting_services_backup_folder}/ --profile {profile}",
+            pty=False,
+            hide="out",
+        ).stdout.strip()
+
+        dates = [
+            re.search(r"\d{12}", x).group(0)
+            for x in listing.split("\n")
+            if re.search(f"^.*{latest}-.*", x)
+        ]
+
         backup_name = f"{latest}-{c.config.hosting_services_backup_folder}-{dates[-1]}.pgdump"
     
     c.run(

--- a/kubesae/utils.py
+++ b/kubesae/utils.py
@@ -20,7 +20,7 @@ def get_backup_from_hosting(c, latest="daily", backup_name=None, list=False):
     Args:
         c (invoke.Context): the running context
         latest (str, optional): Gets the latest backup from the specified temporal period. 
-            Defaults to "daily". Options are "daily", "monthly", "yearly"
+            Defaults to "daily". Options are "daily", "weekly", "monthly", "yearly"
         backup_name(str, optional): A specific backup filename.
         list(bool, optional): If set, will list the contents of the bucket for the projects folder and exit.
     

--- a/kubesae/utils.py
+++ b/kubesae/utils.py
@@ -1,0 +1,80 @@
+import invoke
+import json
+import re
+from kubesae.info import print_ansible_vars
+
+ANSIBLE_HEADER = re.compile(r"^.*\s=>\s")
+BASE_BACKUP_BUCKET = "caktus-hosting-services-backups"
+
+def result_to_json(result: invoke.Result):
+    value = re.sub(ANSIBLE_HEADER, "", result.stdout.strip())
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError as e:
+        print(f"Something went wrong. Expected ansible header. Got {result.stdout.strip()[21]}")
+
+@invoke.task(name="get_db_backup")
+def get_backup_from_hosting(c, latest="daily", backup_name=None, list=False):
+    """Downloads a backup from the caktus hosting services bucket
+
+    Args:
+        c (invoke.Context): the running context
+        latest (str, optional): Gets the latest backup from the specified temporal period. 
+            Defaults to "daily". Options are "daily", "monthly", "yearly"
+        backup_name(str, optional): A specific backup filename.
+        list(bool, optional): If set, will list the contents of the bucket for the projects folder and exit.
+    
+    Usage:
+        $ inv utils.get-db-backup
+            Will copy the latest daily backup to project project root
+        
+        $ inv utils.get-db-backup --latest=monthly
+            Will copy the latest monthly backup to the project root
+
+        $ inv utils.get-db-backup --backup_name=yearly-2021.pgdump
+            Will copy the backup file with the name "yearly-2021.pgdump" to the project root
+        
+        $ inv utils.get-db-backup --list
+            Will list all of the backup files in the bucket for the project.
+    """
+    c.config.env = "production"
+    VALID_PERIODS = ['daily', 'monthly', 'yearly']
+
+    project_backup_folder = print_ansible_vars(
+            c,
+            var="k8s_hosting_services_project_name",
+            yaml="@group_vars/cluster.yaml",
+            pty=False,
+            hide=True,
+    )
+
+    project_backup_folder = result_to_json(project_backup_folder)["k8s_hosting_services_project_name"]
+    
+    if list:
+        c.run(
+            f"aws s3 ls s3://{BASE_BACKUP_BUCKET}/{project_backup_folder}/ --profile caktus"
+        )
+        return
+
+    if latest in VALID_PERIODS and not backup_name:
+
+        listing = c.run(
+            f"aws s3 ls s3://{BASE_BACKUP_BUCKET}/{project_backup_folder}/ --profile caktus",
+            pty=False,
+            hide=True,
+        ).stdout.strip()
+
+        dates = [
+            re.search("\d{12}", x).group(0)
+            for x in listing.split("\n")
+            if re.search(f"^.*{latest}-.*", x)
+        ]
+
+        backup_name = f"{latest}-{project_backup_folder}-{dates[-1]}.pgdump"
+    
+    c.run(
+        f"aws s3 cp s3://{BASE_BACKUP_BUCKET}/{project_backup_folder}/{backup_name} ./{backup_name} --profile caktus"
+    )
+
+utils = invoke.Collection("utils")
+utils.add_task(get_backup_from_hosting)

--- a/kubesae/utils.py
+++ b/kubesae/utils.py
@@ -31,7 +31,7 @@ def get_backup_from_hosting(c, latest="daily", backup_name=None, list=False):
         $ inv utils.get-db-backup --latest=monthly
             Will copy the latest monthly backup to the project root
 
-        $ inv utils.get-db-backup --backup_name=yearly-2021.pgdump
+        $ inv utils.get-db-backup --backup-name=yearly-2021.pgdump
             Will copy the backup file with the name "yearly-2021.pgdump" to the project root
         
         $ inv utils.get-db-backup --list

--- a/tasks.py
+++ b/tasks.py
@@ -29,6 +29,7 @@ ns.configure(
         },
         "cluster": "Myproject-EKS-cluster",
         "repository": "123456789012.dkr.ecr.us-east-1.amazonaws.com/myproject",
+        "hosting_services_backup_folder": "myproject",
         "run": {
             "echo": True,
             "pty": True,


### PR DESCRIPTION
This PR adds a utility task to allow a database backup on sites that have backups configured using the `caktus-hosting` backups.

This changes internal behavior of `get_ansible_vars` and renames it to `print_ansible_vars`, but other than that the process is fairly straightforward.

NOTE: The extraction of filenames is tied fairly tightly to filename definitions found in `caktus-hosting`, so this could cause problems when/if changes are made to caktus-hosting.

closes #20 