### PR TITLE
Make our playbook command compatible with boto (for AssumedRoles)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 invoke-kubesae
-=============
+==============
 
 The kubesae library is an `invoke <http://docs.pyinvoke.org/en/stable/>`_ tasks library
 to provide some basic management tasks for working with a kubernetes cluster.
@@ -86,6 +86,15 @@ configuration each task uses.
             },
         }
     )
+
+.. note::
+   The ``profile_name`` in the config above is only used when you run custom playbooks,
+   not the main deploy playbook. It is used because boto doesn't work well with
+   AssumedRoles, so if your playbook needs an AssumedRole we have to convert the role
+   credentials to standard AWS access_key/secret credentials and we use the profile above
+   to do that. This assumes that all devs in your project are using the same profile
+   name, but if you want to customize it, you can create a project-level task to
+   customize it.
 
 
 Now you can see all of the currently available tasks by running::

--- a/README.rst
+++ b/README.rst
@@ -77,6 +77,7 @@ configuration each task uses.
             "app": "appname",
             "aws": {
                 "region": "us-west-2",
+                "profile_name": "my-aws-profile",  # a profile from .aws/credentials
             },
             "repository": "123456789012.dkr.ecr.us-east-1.amazonaws.com/myproject",
             "run": {

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1,6 +1,13 @@
 Releases
 ========
 
+v0.0.13, 2021-FIXME
+~~~~~~~~~~~~~~~~~~~~
+* Make custom playbooks compatible with boto. This requires that you add a
+  ``aws.profile_name`` key in your tasks definition which points to an AWS_PROFILE that
+  is an AssumedRole.
+
+
 v0.0.12, 2021-02-18
 ~~~~~~~~~~~~~~~~~~~
 * Add support for Ansible `--limit` with `deploy.playbook` task

--- a/kubesae/ansible/deploy.py
+++ b/kubesae/ansible/deploy.py
@@ -33,6 +33,28 @@ def ansible_deploy(c, env=None, tag=None):
         c.run(f"ansible-playbook {playbook} -l {env} -e k8s_container_image_tag={tag} -vv")
 
 
+def get_boto_env(profile_name):
+    """
+    Use an existing AWS_PROFILE to get the other AWS credentials that boto needs.
+
+    This is a temporary workaround for the bug found here:
+    https://github.com/caktus/ansible-role-django-k8s/issues/29#issuecomment-665767426
+
+    If the Ansible IAM role ever gets upgraded to use boto3 instead of boto, or if boto
+    itself gets upgraded to handle AWS profiles (less likely), then this function can be
+    removed.
+    """
+    import boto3
+    session = boto3.Session(profile_name=profile_name)
+    credentials = session.get_credentials().get_frozen_credentials()
+    return {
+        'AWS_ACCESS_KEY_ID': credentials.access_key,
+        'AWS_SECRET_ACCESS_KEY': credentials.secret_key,
+        'AWS_SECURITY_TOKEN': credentials.token,
+        'AWS_SESSION_TOKEN': credentials.token,
+    }
+
+
 @invoke.task
 def ansible_playbook(c, name, extra="", verbosity=1):
     """Run a specified Ansible playbook.
@@ -46,8 +68,14 @@ def ansible_playbook(c, name, extra="", verbosity=1):
 
     Usage: inv deploy.playbook <PLAYBOOK>.yaml --extra=<EXTRA> --verbosity=<VERBOSITY>
     """
+    if c.config.get("aws") and c.config.aws.get("profile_name"):
+        # if we're using AWS and using an AWS_PROFILE, then we'll adjust the shell
+        # environment for boto's sake
+        shell_env = get_boto_env(c.config.aws.get("profile_name"))
+    else:
+        shell_env = {}
     with c.cd("deploy/"):
-        c.run(f"ansible-playbook {name} {extra} -{'v'*verbosity}")
+        c.run(f"ansible-playbook {name} {extra} -{'v'*verbosity}", env=shell_env)
 
 
 deploy = invoke.Collection("deploy")

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
     author_email='',
     description='',
     install_requires=[
+        'boto3>=1.16',
         'invoke>=1.4',
         'colorama>=0.4',
         'ansible>=2.9',

--- a/tasks.py
+++ b/tasks.py
@@ -26,6 +26,7 @@ ns.configure(
         "app": "myproject",
         "aws": {
             "region": "us-west-2",
+            "profile_name": "my-aws-profile",  # a profile from .aws/credentials
         },
         "cluster": "Myproject-EKS-cluster",
         "repository": "123456789012.dkr.ecr.us-east-1.amazonaws.com/myproject",


### PR DESCRIPTION
This is an attempted fix for https://github.com/caktus/ansible-role-django-k8s/issues/29#issuecomment-665767426

~I haven't yet tested this out,~ but wanted to see what people thought of the approach.

Update. I've now tested it out locally, and it works. If I don't have `profile_name` set in my tasks.py, then it fails. If I set `aws.profile_name = saguaro-cluster`, then it succeeds.