### PR TITLE
Allow verbosity of zero

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2020, Caktus Consulting Group, LLC
+Copyright (c) 2020-2021, Caktus Consulting Group, LLC
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/README.rst
+++ b/README.rst
@@ -153,6 +153,9 @@ deploy
 
     Deploy your k8s application. (Default)
 
+    WARNING: if you are running this in CI, make sure to set `--verbosity=0` to prevent
+    environment variables from being logged in plain text in the CI console.
+
     Prereq: deploy.install
 
     Config:
@@ -160,6 +163,8 @@ deploy
         env: Name of environment to deploy to
 
         tag: Image tag to deploy (default: same as default tag for build & push)
+
+        verbosity: integer level of verbosity from 0 to 4 (most verbose)
 
 install
 ~~~~~~~
@@ -171,6 +176,16 @@ playbook
 
     Run a specified Ansible playbook, located in the ``deploy/`` directory.
 
+    WARNING: if you are running this in CI, make sure to set `--verbosity=0` to prevent
+    environment variables from being logged in plain text in the CI console.
+
+    Config:
+
+        name: The name of the Ansible playbook to run, including the extension
+
+        extra: Additional command line arguments to ansible-playbook
+
+        verbosity: integer level of verbosity from 0 to 4 (most verbose)
 
 GCP
 ---

--- a/README.rst
+++ b/README.rst
@@ -145,6 +145,12 @@ docker-login
 
         repository: Name of docker repository, e.g. dockerhub.com/myproject.
 
+sync-media
+~~~~~~~~~~
+
+    Syncs a media bucket between two namespaces (e.g. `production` to `staging`, or
+    `staging` to `local`).
+
 Deploy
 ------
 
@@ -160,7 +166,7 @@ deploy
 
     Config:
 
-        env: Name of environment to deploy to
+        env: The target ansible host ("staging", "production", etc ...)
 
         tag: Image tag to deploy (default: same as default tag for build & push)
 
@@ -174,7 +180,8 @@ install
 playbook
 ~~~~~~~~
 
-    Run a specified Ansible playbook, located in the ``deploy/`` directory.
+    Run a specified Ansible playbook, located in the ``deploy/`` directory. Used to run
+    a different playbook than the default playbook.
 
     WARNING: if you are running this in CI, make sure to set `--verbosity=0` to prevent
     environment variables from being logged in plain text in the CI console.
@@ -214,6 +221,12 @@ docker-login
 
         repository: Name of docker repository, e.g. us.gcr.io/myproject/myproject
 
+sync-media
+~~~~~~~~~~
+
+    Syncs a media bucket between two namespaces (e.g. `production` to `staging`, or
+    `staging` to `local`).
+
 Image
 -----
 
@@ -224,10 +237,15 @@ build
 
     Config:
 
-    Config:
+        tag: tag to apply. (Will be generated from git branch/commit
+        if not set).
+
+    Params:
 
         tag: tag to apply. (Will be generated from git branch/commit
         if not set).
+
+        dockerfile: A non-standard Dockerfile location and/or name
 
 push
 ~~~~
@@ -241,6 +259,11 @@ push
         repository: Name of docker repository, e.g. dockerhub.com/myproject.
 
         tag: tag to push. (Will be generated from git branch/commit
+        if not set).
+
+    Params:
+
+        tag: tag to apply. (Will be generated from git branch/commit
         if not set).
 
 stop
@@ -259,18 +282,50 @@ up
 
     Brings up the deployable image locally in docker-compose for testing
 
+
+Info
+----
+
+get-ansible-vars
+~~~~~~~~~~~~~~~~
+
+    Inspect ansible variables
+
+    Params:
+
+        var: A variable available to a host when called.
+
+pod-stats
+~~~~~~~~~
+
+    Report total pods vs pod capacity in a cluster.
+
+
 Pod
 ---
+
+clean-collectstatic
+~~~~~~~~~~~~~~~~~~~
+
+    Removes all collectstatic pods
+
+    Config:
+
+        namespace: the k8s namespace that will be cleaned
 
 clean-debian
 ~~~~~~~~~~~~
 
-    Removes the exited ephemeral debian pod
+    Clears away the old debian pod so a new one may live.
 
 clean-migrations
 ~~~~~~~~~~~~~~~~
 
     Removes all migration jobs
+
+    Config:
+
+        namespace: the k8s namespace that will be cleaned
 
 debian
 ~~~~~~
@@ -283,15 +338,52 @@ fetch_namespace_var
     Takes a variable name that may be present on a running container. Queries the
     container for the value of that variable and returns it as a Result object.
 
+    Config:
+
+        namespace: the k8s namespace that will be cleaned
+
+        container_name: Name of the Docker container.
+
+    Params:
+
+        fetch_var (str): An environment variable expected on the target container
+
+        hide (bool, optional): Hides the stdout if True. Defaults to False.
+
 get_db_dump
 ~~~~~~~~~~~
 
     Get a dump of an environment's database
 
+    Config:
+
+        namespace: the k8s namespace that will be cleaned
+
+        container_name: Name of the Docker container.
+
+    Params:
+
+        db_var (str): The variable name that the database connection is stored in.
+
+        filename (string, optional): A filename to store the dump. If None, will default
+	to {namespace}_database.dump.
+
 restore_db_from_dump
-~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~
 
     Load a database dump file into an environment's database
+
+    Config:
+
+        namespace: the k8s namespace that will be cleaned
+
+        container_name: Name of the Docker container.
+
+    Params:
+
+        db_var (str): The variable the database connection is stored in.
+
+        filename (string): An filename of the dump to restore.
 
 shell
 ~~~~~
@@ -301,7 +393,3 @@ shell
     Config:
 
         container_name: Name of the Docker container.
-
-sync-media
-~~~~~~~~~~
-    Syncs a media bucket between two namespaces (e.g. `production` to `staging`, or `staging` to `local`).

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1,6 +1,18 @@
 Releases
 ========
 
+v0.0.11, 2021-02-02
+~~~~~~~~~~~~~~~~~~~
+* Add verbosity flag to all ansible commands, and allow verbosity=0, with a WARNING
+  explaining to use that for CI deploys (#27)
+
+
+v0.0.10, 2021-01-13
+~~~~~~~~~~~~~~~~~~~
+* Add ``sync-media`` task (#24)
+* Add ``info`` package, with tasks to get ansible variables and pod statistics (#23)
+
+
 v0.0.9, 2020-10-29
 ~~~~~~~~~~~~~~~~~~
 * Add command to run an alternate playbook (#21)

--- a/kubesae/ansible/deploy.py
+++ b/kubesae/ansible/deploy.py
@@ -26,16 +26,24 @@ def get_verbosity_flag(verbosity):
     return v_flag
 
 
-@invoke.task(default=True)
+@invoke.task(pre=[install_requirements], default=True)
 def ansible_deploy(c, env=None, tag=None, verbosity=1):
     """Deploy K8s application.
 
-    Params:
+    WARNING: if you are running this in CI, make sure to set `--verbosity=0` to prevent
+    environment variables from being logged in plain text in the CI console.
+
+    Config:
         env: The target ansible host ("staging", "production", etc ...)
-        tag: The image tag in the registry to deploy
+        tag: Image tag to deploy (default: same as default tag for build & push)
         verbosity: integer level of verbosity from 0 to 4 (most verbose)
 
-    Usage: inv deploy.deploy --env=<ENVIRONMENT> --tag=<TAG>
+    Params:
+        env: The target ansible host ("staging", "production", etc ...)
+        tag: Image tag to deploy (default: same as default tag for build & push)
+        verbosity: integer level of verbosity from 0 to 4 (most verbose)
+
+    Usage: inv deploy.deploy --env=<ENVIRONMENT> --tag=<TAG> --verbosity=<VERBOSITY>
     """
     if env is None:
         env = c.config.env
@@ -51,7 +59,11 @@ def ansible_deploy(c, env=None, tag=None, verbosity=1):
 def ansible_playbook(c, name, extra="", verbosity=1):
     """Run a specified Ansible playbook.
 
-    Used to run a different playbook than the default playbook.
+    Run a specified Ansible playbook, located in the ``deploy/`` directory. Used to run
+    a different playbook than the default playbook.
+
+    WARNING: if you are running this in CI, make sure to set `--verbosity=0` to prevent
+    environment variables from being logged in plain text in the CI console.
 
     Params:
         name: The name of the Ansible playbook to run, including the extension
@@ -59,6 +71,7 @@ def ansible_playbook(c, name, extra="", verbosity=1):
         verbosity: integer level of verbosity from 0 to 4 (most verbose)
 
     Usage: inv deploy.playbook <PLAYBOOK.YAML> --extra=<EXTRA> --verbosity=<VERBOSITY>
+
     """
     v_flag = get_verbosity_flag(verbosity)
     with c.cd("deploy/"):

--- a/kubesae/ansible/deploy.py
+++ b/kubesae/ansible/deploy.py
@@ -14,13 +14,26 @@ def install_requirements(c):
         c.run(f"ansible-galaxy install -f -r '{req_file}' -p roles/")
 
 
-@invoke.task(pre=[install_requirements], default=True)
-def ansible_deploy(c, env=None, tag=None):
+def get_verbosity_flag(verbosity):
+    """
+    Given an integer, return a string with that number of `v` characters, prefixed
+    by a hyphen, for use as a flag to the ansible-playbook command. If verbosity is
+    zero, return the empty string.
+    """
+    v_flag = ""
+    if verbosity:
+        v_flag = "-{'v'*verbosity}"
+    return v_flag
+
+
+@invoke.task(default=True)
+def ansible_deploy(c, env=None, tag=None, verbosity=1):
     """Deploy K8s application.
 
     Params:
         env: The target ansible host ("staging", "production", etc ...)
         tag: The image tag in the registry to deploy
+        verbosity: integer level of verbosity from 0 to 4 (most verbose)
 
     Usage: inv deploy.deploy --env=<ENVIRONMENT> --tag=<TAG>
     """
@@ -29,8 +42,9 @@ def ansible_deploy(c, env=None, tag=None):
     if tag is None:
         tag = c.config.tag
     playbook = "deploy.yaml" if os.path.exists("deploy/deploy.yaml") else "deploy.yml"
+    v_flag = get_verbosity_flag(verbosity)
     with c.cd("deploy/"):
-        c.run(f"ansible-playbook {playbook} -l {env} -e k8s_container_image_tag={tag} -vv")
+        c.run(f"ansible-playbook {playbook} -l {env} -e k8s_container_image_tag={tag} {v_flag}")
 
 
 @invoke.task
@@ -42,12 +56,13 @@ def ansible_playbook(c, name, extra="", verbosity=1):
     Params:
         name: The name of the Ansible playbook to run, including the extension
         extra: Additional command line arguments to ansible-playbook
-        verbosity: integer level of verbosity from 1 to 4 (most verbose)
+        verbosity: integer level of verbosity from 0 to 4 (most verbose)
 
-    Usage: inv deploy.playbook <PLAYBOOK>.yaml --extra=<EXTRA> --verbosity=<VERBOSITY>
+    Usage: inv deploy.playbook <PLAYBOOK.YAML> --extra=<EXTRA> --verbosity=<VERBOSITY>
     """
+    v_flag = get_verbosity_flag(verbosity)
     with c.cd("deploy/"):
-        c.run(f"ansible-playbook {name} {extra} -{'v'*verbosity}")
+        c.run(f"ansible-playbook {name} {extra} {v_flag}")
 
 
 deploy = invoke.Collection("deploy")

--- a/kubesae/image.py
+++ b/kubesae/image.py
@@ -58,7 +58,8 @@ def push_image(c, tag=None):
     to the repository defined for this task.
 
     Params:
-        tag: A user supplied tag for the generated image.
+        tag: tag to apply. (Will be generated from git branch/commit
+        if not set).
 
     Usage: inv push --tag=<TAG>
     """

--- a/kubesae/info.py
+++ b/kubesae/info.py
@@ -3,24 +3,28 @@ import yaml
 
 @invoke.task(default=True)
 def get_ansible_vars(c, var=None):
-    """A command to inspect any ansible varible by environment. If no variable is specified then it will
-    print out the current k8s environment variables.
+    """Inspect ansible variables
+
+    Displays Ansible variables in the specified environment. If no variable is specified
+    then it will print out the current k8s environment variables.
 
     Params:
         var: A variable available to a host when called.
 
     Usage: inv <ENVIRONMENT> info
            inv <ENVIRONMENT> info --var=<ANSIBLE_VAR>
+
     """
     if not var:
         var = "k8s_environment_variables"
     with c.cd("deploy/"):
         c.run(f"ansible {c.config.env} -m debug -a var='{var}' -e '@host_vars/{c.config.env}.yml'")
 
+
 @invoke.task
 def pod_stats(c):
     """Report total pods vs pod capacity in a cluster.
-    
+
     Params: None
 
     Usage: inv info.pod-stats

--- a/kubesae/pod.py
+++ b/kubesae/pod.py
@@ -38,6 +38,7 @@ def clean_collectstatic(c):
         f"kubectl delete pods -n {c.config.namespace} -ljob-name=collectstatic"
     )
 
+
 @invoke.task
 def clean_migrations(c):
     """Removes all migration pods
@@ -48,12 +49,13 @@ def clean_migrations(c):
         f"kubectl delete pods -n {c.config.namespace} -ljob-name=migrate"
     )
 
+
 @invoke.task
 def fetch_namespace_var(c, fetch_var, hide=False):
     """Takes a variable name that may be present on a running container. Queries the
     container for the value of that variable and returns it as a Result object.
 
-    Args:
+    Params:
         fetch_var (str): An environment variable expected on the target container
         hide (bool, optional): Hides the stdout if True. Defaults to False.
     Returns:
@@ -67,13 +69,14 @@ def fetch_namespace_var(c, fetch_var, hide=False):
     )
     return c.run(command, hide=hide)
 
+
 @invoke.task()
 def get_db_dump(c, db_var, filename=None):
     """Get a database dump (into the filename).
 
-    Args:
+    Params:
         db_var (str): The variable name that the database connection is stored in.
-        filename (string, optional): A filename to store the dump. Defaults to None.
+        filename (string, optional): A filename to store the dump. If None, will default to {namespace}_database.dump.
     Usage:
         inv <ENVIRONMENT> pod.get-db-dump --db-var="<DB_VAR_NAME>"
     """
@@ -87,11 +90,12 @@ def get_db_dump(c, db_var, filename=None):
     )
     c.run(command)
 
+
 @invoke.task()
 def restore_db_from_dump(c, db_var, filename):
     """Load a database dump from a file.
 
-    Args:
+    Params:
         db_var (str): The variable the database connection is stored in.
         filename (string): An filename of the dump to restore.
     Usage:

--- a/kubesae/providers/aws.py
+++ b/kubesae/providers/aws.py
@@ -46,6 +46,7 @@ def configure_eks_kubeconfig(c, cluster=None, region=None):
         region = c.config.aws.get("region", "us-east-1")
     c.run(f"aws eks update-kubeconfig --name {cluster} --region {region}")
 
+
 @invoke.task(name="sync_media")
 def sync_media_tree(
     c,
@@ -56,15 +57,15 @@ def sync_media_tree(
     dry_run=False,
     delete=False,
 ):
-    """Sync an S3 media tree for a given environment/namespace to another. 
+    """Syncs a media bucket between two namespaces (e.g. `production` to `staging`, or `staging` to `local`).
 
-    Args:
-        sync_to      (string, required): A deployment host defined in ansible host_vars (e.g. "production", "staging", "dev"), or "local". 
+    Params:
+        sync_to      (string, required): A deployment host defined in ansible host_vars (e.g. "production", "staging", "dev"), or "local".
             If set to "local" the tree will sync to a local folder. DEFAULT: staging.
         media_bucket (string, required): The variable name for media defined in settings and host_vars. DEFAULT: MEDIA_STORAGE_BUCKET_NAME
         acl          (string, required): Sets the access policy on each object. DEFAULT: public-read
                                          Possible values: [
-                                            private, public-read, public-read-write, authenticated-read, 
+                                            private, public-read, public-read-write, authenticated-read,
                                             aws-exec-read, bucket-owner-read,bucket-owner-full-control,
                                             log-delivery-write
                                         ]
@@ -74,16 +75,16 @@ def sync_media_tree(
         local        (boolean, optional): If set, syncs media files to the location defined by the "local_target" parameter.
 
     Usage:
-        inv production aws.sync-media --dry-run: 
+        inv production aws.sync-media --dry-run:
             Will simulate a sync from production to staging using the s3 bucket defined in MEDIA_STORAGE_BUCKET with no acl applied.
-        
+
         inv production aws.sync-media --dry-run --delete
             Will display the files that will be deleted from the staging s3 bucket defined in MEDIA_STORAGE_BUCKET.
-        
+
         inv production aws.sync-media --media-bucket="MEDIA" --acl public-read --delete
             Will sync files from the s3 bucket defined in the environment variable "MEDIA" to a staging bucket with the acl of each object set to 'public-read', and
             will delete objects on the staging bucket that do not exist on the production bucket.
-        
+
         inv production aws.sync-media --sync-to="local" --local-target="./public/media"
             Will sync files from the production bucket to "<PROJECT_ROOT>/public/media"
     """
@@ -91,7 +92,7 @@ def sync_media_tree(
     target_media_name = ""
     dr = ""
     dl = ""
-    
+
     source_media_name = fetch_namespace_var(
         c, fetch_var=f"{media_bucket}"
     ).stdout.strip()

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='invoke-kubesae',
-    version='0.0.9',
+    version='0.0.11',
     packages=find_packages(),
     url='https://github.com/caktus/invoke-kubesae',
     author='Caktus Group',


### PR DESCRIPTION
This allows a verbosity of zero to be set via the command line, but keeps the default at 1, which is useful for local usage. I believe we'll just need to have projects update to this version of kubesae and then add `--verbosity=0` to their invocation.