### PR TITLE
Add --limit support to deploy.playbook task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode
 __pycache__/
 *.pyc
+*.egg-info

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1,6 +1,12 @@
 Releases
 ========
 
+v0.0.12, 2021-02-18
+~~~~~~~~~~~~~~~~~~~
+* Add support for Ansible `--limit` with `deploy.playbook` task
+* Fix bug with verbosity flag
+
+
 v0.0.11, 2021-02-02
 ~~~~~~~~~~~~~~~~~~~
 * Add verbosity flag to all ansible commands, and allow verbosity=0, with a WARNING

--- a/kubesae/ansible/deploy.py
+++ b/kubesae/ansible/deploy.py
@@ -22,7 +22,7 @@ def get_verbosity_flag(verbosity):
     """
     v_flag = ""
     if verbosity:
-        v_flag = "-{'v'*verbosity}"
+        v_flag = f"-{'v'*verbosity}"
     return v_flag
 
 

--- a/kubesae/ansible/deploy.py
+++ b/kubesae/ansible/deploy.py
@@ -56,7 +56,7 @@ def ansible_deploy(c, env=None, tag=None, verbosity=1):
 
 
 @invoke.task
-def ansible_playbook(c, name, extra="", verbosity=1):
+def ansible_playbook(c, name, extra="", verbosity=1, limit=""):
     """Run a specified Ansible playbook.
 
     Run a specified Ansible playbook, located in the ``deploy/`` directory. Used to run
@@ -73,9 +73,13 @@ def ansible_playbook(c, name, extra="", verbosity=1):
     Usage: inv deploy.playbook <PLAYBOOK.YAML> --extra=<EXTRA> --verbosity=<VERBOSITY>
 
     """
+    if limit:
+        limit = f"-l{limit}"
+    if "env" in c.config and c.config.env and not limit:
+        limit = f"-l{c.config.env}"
     v_flag = get_verbosity_flag(verbosity)
     with c.cd("deploy/"):
-        c.run(f"ansible-playbook {name} {extra} {v_flag}")
+        c.run(f"ansible-playbook {name} {limit} {extra} {v_flag}")
 
 
 deploy = invoke.Collection("deploy")


### PR DESCRIPTION
Supports either picking up the `c.config.env` or overriding with `-l`, e.g.:

```
inv staging deploy.playbook -n play-deploy-cluster.yml
# or
inv deploy.playbook -l staging -n play-deploy-cluster.yml
```