### PR TITLE
Adds a path extension for media trees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__/
 *.pyc
 *.egg-info
+.idea

--- a/kubesae/providers/aws.py
+++ b/kubesae/providers/aws.py
@@ -54,7 +54,7 @@ def sync_media_tree(
     media_bucket="MEDIA_STORAGE_BUCKET_NAME",
     acl="private",
     local_target="./media",
-    append_path="",
+    bucket_path="",
     dry_run=False,
     delete=False,
 ):
@@ -72,7 +72,7 @@ def sync_media_tree(
                                         ]
         local_target (string, optional): Sets a target directory for local syncs. Defaults to "./media"
         dry_run      (boolean, optional): Outputs the result to stdout without applying the action
-        append_path (string, optional): If set, appends to the bucket the extra path information.
+        bucket_path (string, optional): If set, appends to the bucket the extra path information.
         delete       (boolean, optional): If set, deletes files on the target that do not exist on the source.
 
     Usage:
@@ -89,7 +89,7 @@ def sync_media_tree(
         inv production aws.sync-media --sync-to="local" --local-target="./public/media"
             Will sync files from the production bucket to "<PROJECT_ROOT>/public/media"
 
-        inv production aws.sync-media --sync-to="local" --local-target="./public/media/chandler-bing" --append-path="chandler-bing"
+        inv production aws.sync-media --sync-to="local" --local-target="./public/media/chandler-bing" --bucket-path="chandler-bing"
     """
     sync_from = c.config.env
     target_media_name = ""
@@ -100,8 +100,8 @@ def sync_media_tree(
         c, fetch_var=f"{media_bucket}"
     ).stdout.strip()
 
-    if append_path:
-        source_media_name += f"/{append_path.strip('/')}"
+    if bucket_path:
+        source_media_name += f"/{bucket_path.strip('/')}"
 
     if sync_from == sync_to:
         print("Source and Target environments are the same. Nothing to be done.")

--- a/kubesae/providers/aws.py
+++ b/kubesae/providers/aws.py
@@ -54,6 +54,7 @@ def sync_media_tree(
     media_bucket="MEDIA_STORAGE_BUCKET_NAME",
     acl="private",
     local_target="./media",
+    append_path="",
     dry_run=False,
     delete=False,
 ):
@@ -71,8 +72,8 @@ def sync_media_tree(
                                         ]
         local_target (string, optional): Sets a target directory for local syncs. Defaults to "./media"
         dry_run      (boolean, optional): Outputs the result to stdout without applying the action
+        append_path (string, optional): If set, appends to the bucket the extra path information.
         delete       (boolean, optional): If set, deletes files on the target that do not exist on the source.
-        local        (boolean, optional): If set, syncs media files to the location defined by the "local_target" parameter.
 
     Usage:
         inv production aws.sync-media --dry-run:
@@ -87,6 +88,8 @@ def sync_media_tree(
 
         inv production aws.sync-media --sync-to="local" --local-target="./public/media"
             Will sync files from the production bucket to "<PROJECT_ROOT>/public/media"
+
+        inv production aws.sync-media --sync-to="local" --local-target="./public/media/chandler-bing" --append-path="chandler-bing"
     """
     sync_from = c.config.env
     target_media_name = ""
@@ -96,6 +99,9 @@ def sync_media_tree(
     source_media_name = fetch_namespace_var(
         c, fetch_var=f"{media_bucket}"
     ).stdout.strip()
+
+    if append_path:
+        source_media_name += f"/{append_path.strip('/')}"
 
     if sync_from == sync_to:
         print("Source and Target environments are the same. Nothing to be done.")


### PR DESCRIPTION
Opened this as a PR to support a need on rebar. It adds parameter `bucket_path`, which if set is added to the s3 bucket url.

Motivation:

Rebar is a multi-site project with its media resources housed in the same bucket, but each resource tree is distinguished by its namespace as the TLD for its media tree.

While this probably won't come up on a lot of projects, it is still, I think, useful to be able to target deeper in the media tree if necessary.
