### PR TITLE
Add choices to pod debian

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1,6 +1,14 @@
 Releases
 ========
 
+v0.0.20, 2022-12-08
+~~~~~~~~~~~~~~~~~~~
+* Adds support for selecting the flavor of debian launched with pod.debian.
+
+v0.0.19, 2022-19-05
+~~~~~~~~~~~~~~~~~~~
+* Allow restoring a db from a different schema to another without complaints.
+
 v0.0.18, 2021-14-08
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/kubesae/pod.py
+++ b/kubesae/pod.py
@@ -33,6 +33,7 @@ def debian(c, debian_flavor="bullseye"):
         stretch: psql-client-9
 
     Usage: inv pod.debian
+    Usage: inv pod.debian --debian-flavor stretch
     """
     debian_flavors = ['bullseye', 'buster', 'stretch']
     if debian_flavor not in debian_flavors:

--- a/kubesae/pod.py
+++ b/kubesae/pod.py
@@ -21,12 +21,24 @@ def clean_debian(c):
 
 
 @invoke.task(pre=[clean_debian])
-def debian(c):
-    """An ephemeral container with which to run sysadmin tasks on the cluster
+def debian(c, debian_flavor="bullseye"):
+    """An ephemeral container with which to run sysadmin tasks on the cluster.
+
+    The default image is bullseye-slim, but we can select the image we need from a
+    list of supported images: ('bullseye', 'buster', 'stretch')
+
+    Postgres client provided:
+        bullseye: psql-client-13
+        buster: psql-client-11
+        stretch: psql-client-9
 
     Usage: inv pod.debian
     """
-    c.run(f"kubectl run -it debian --image=debian:bullseye-slim --restart=Never -- bash")
+    debian_flavors = ['bullseye', 'buster', 'stretch']
+    if debian_flavor not in debian_flavors:
+        print(f"{debian_flavor} not in the valid list: {debian_flavors}")
+        return
+    c.run(f"kubectl run -it debian --image=debian:{debian_flavor}-slim --restart=Never -- bash")
 
 
 @invoke.task

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="invoke-kubesae",
-    version="0.0.19",
+    version="0.0.20",
     packages=find_packages(exclude=["tests"]),
     url="https://github.com/caktus/invoke-kubesae",
     author="Caktus Group",


### PR DESCRIPTION
This PR adds the ability to specify the flavor of debian needed when using the `pod.debian` task.

This is necessary because we will sometimes have projects using different database versions that will not be supported by the default psql client provided by a single version of debian.


