### PR TITLE
fix get-db-dump

### DIFF
--- a/kubesae/pod.py
+++ b/kubesae/pod.py
@@ -114,11 +114,10 @@ def restore_db_from_dump(c,  filename, db_var=DEFAULT_DB_VAR):
     Usage:
         inv <ENVIRONMENT> pod.restore-db-from-dump --db-var="<DB_VAR_NAME>" --filename="<PATH/TO/DBFILE>"
     """
-    database_url = fetch_namespace_var(c, fetch_var=db_var, hide=True).stdout.strip()
     command = (
         f"kubectl --namespace {c.config.namespace} exec -i "
-        f"deploy/{c.config.container_name} -- "
-        f"pg_restore --no-privileges --no-owner --clean --if-exists --dbname {database_url} < {filename}"
+        f"deploy/{c.config.container_name} -- sh -c '"
+        f"pg_restore --no-privileges --no-owner --clean --if-exists --dbname ${db_var}' < {filename}"
     )
     c.run(command)
 

--- a/kubesae/pod.py
+++ b/kubesae/pod.py
@@ -94,13 +94,12 @@ def get_db_dump(c, db_var=DEFAULT_DB_VAR, filename=None):
     Usage:
         inv <ENVIRONMENT> pod.get-db-dump --db-var="<DB_VAR_NAME>"
     """
-    database_url = fetch_namespace_var(c, fetch_var=db_var, hide=True).stdout.strip()
     if not filename:
         filename = f"{c.config.namespace}_database.dump"
     command = (
         f"kubectl --namespace {c.config.namespace} exec -i "
-        f"deploy/{c.config.container_name} -- pg_dump -Fc --no-owner --clean "
-        f"--dbname {database_url} > {filename}"
+        f"deploy/{c.config.container_name} -- sh -c 'pg_dump -Fc --no-owner --clean "
+        f"--dbname ${db_var}' > {filename}"
     )
     c.run(command)
 


### PR DESCRIPTION
As a workaround for #47 we can simply evaluate the variable in the remote container instead of transferring it locally first.

Fixes this error:
```
$ inv staging pod.get-db-dump --db-var="DATABASE_URL"
kubectl --namespace <snip> exec -i deploy/web -- pg_dump -Fc --no-owner --clean --dbname W1020 20:38:47.334596 1586748 gcp.go:119] WARNING: the gcp auth plugin is deprecated in v1.22+, unavailable in v1.26+; use gcloud instead.
To learn more, consult https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
postgres://<snip> > caktus-website-staging_database.dump
W1020 20:38:47.959972 1586794 gcp.go:119] WARNING: the gcp auth plugin is deprecated in v1.22+, unavailable in v1.26+; use gcloud instead.
To learn more, consult https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
pg_dump: error: too many command-line arguments (first is "20:38:47.334596")
Try "pg_dump --help" for more information.
command terminated with exit code 1
/bin/bash: use: command not found
/bin/bash: line 1: To: command not found
/bin/bash: line 2: postgres://<snip>: No such file or directory
```