### PR TITLE
Fix SSHing Into Pod

### DIFF
--- a/kubesae/pod.py
+++ b/kubesae/pod.py
@@ -10,7 +10,7 @@ def shell(c):
     Usage: inv <ENVIRONMENT> pod.shell
     """
     c.run(
-        f"kubectl exec -it deploy/{c.config.container_name} -n {c.config.namespace} bash"
+        f"kubectl exec -it deploy/{c.config.container_name} -n {c.config.namespace} -- bash"
     )
 
 


### PR DESCRIPTION
This PR fixes the current inability to `SSH` into pods without getting the current error.

```
 > inv staging pod.shell                                                        

error: exec [POD] [COMMAND] is not supported anymore. Use exec [POD] -- [COMMAND] instead
See 'kubectl exec -h' for help and examples
```
